### PR TITLE
Feature/tiebreak

### DIFF
--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -332,9 +332,9 @@ class TurnManager:
                         if row_id in (1, 2):
                             lines[row_id - 1] += 1
 
-        if lines[self.current_player.id % 2] > lines[(self.current_player.id + 1) % 2]:
+        if lines[self.current_player.id - 1] > lines[self.other_player.id - 1]:
             self.current_player.won = True
-        elif lines[self.current_player.id % 2] < lines[(self.current_player.id + 1) % 2]:
+        elif lines[self.current_player.id - 1] < lines[self.other_player.id - 1]:
             self.other_player.won = True
         else:
             print(":|")

--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -211,7 +211,7 @@ class TurnManager:
                             self.current_player.won = True
                             self.game_over = True
 
-                    if len(set(np.where(self.game_board.board[0] == 0)[0]) - set(self.game_board.frozen_columns.keys())) == 0:
+                    if 0 not in self.game_board.board[0]:
                         if self.sets[self.current_player.id] > self.sets[self.other_player.id]:
                             self.current_player.won = True
                         elif self.sets[self.current_player.id] < self.sets[self.other_player.id]:
@@ -219,6 +219,9 @@ class TurnManager:
                         else:
                             self.tiebreak(self.game_board.board)
                         self.game_over = True
+                    else:
+                        while len(set(np.where(self.game_board.board[0] == 0)[0]) - set(self.game_board.frozen_columns.keys())) == 0:
+                            self.switch_turn()
                     
                     if current_tool.ends_turn:
                         self.remaining_drops -= 1

--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -162,7 +162,7 @@ class TurnManager:
                     if current_tool.id in (2, 4):
                         self.check_for_break(self.game_board.board)
 
-                    if current_tool.id in (-1, 0):
+                    if current_tool.id == 0:
                         d = -1
                         v = 10
                         fall_positions = []
@@ -199,16 +199,19 @@ class TurnManager:
                     self.tool_index = 0
 
                     if current_tool.id == 4:
-                        self.current_player.tools = [Tool(-1, held_tile_id, True, False, False, True, False), Tool(0, 3, True, True,  False, True, False)] + self.current_player.tools
+                        self.current_player.tools = [Tool(0, held_tile_id, True, False, False, True, False), Tool(0, 3, True, True,  False, True, False)] + self.current_player.tools
     
                     if current_tool.tile_id in (1, 1.5, 2):
-                        if current_tool.id == -1 and current_tool.tile_id != self.current_player.id:
+                        if current_tool.tile_id == self.other_player.id:
                             if self.winning_move(self.game_board.board, current_tool.tile_id, (ROW_COUNT - position[1] - 1, position[0])):  
                                 self.other_player.won = True    
                                 self.game_over = True
                         elif self.winning_move(self.game_board.board, self.current_player.id, (ROW_COUNT - position[1] - 1, position[0])):  
                             self.current_player.won = True
                             self.game_over = True
+
+                    if 0 not in self.game_board.board[0]:
+                        print("hi")
                     
                     if current_tool.ends_turn:
                         self.remaining_drops -= 1

--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -292,7 +292,7 @@ class TurnManager:
     def tiebreak(self, board):
         lines = [0, 0]
 
-        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 1):
+        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 2):
             for r in range(ROW_COUNT):
                 for i in range(NUMBER_TO_WIN - 2):
                     if board[r][c + i] != board[r][c + i + 1]:
@@ -303,7 +303,7 @@ class TurnManager:
                             lines[row_id - 1] += 1
 
         for c in range(COLUMN_COUNT):
-            for r in range(ROW_COUNT - NUMBER_TO_WIN + 1):
+            for r in range(ROW_COUNT - NUMBER_TO_WIN + 2):
                 for i in range(NUMBER_TO_WIN - 2):
                     if board[r + i][c] != board[r + i + 1][c]:
                         break
@@ -312,8 +312,8 @@ class TurnManager:
                         if row_id in (1, 2):
                             lines[row_id - 1] += 1
 
-        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 1):
-            for r in range(ROW_COUNT - NUMBER_TO_WIN + 1):
+        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 2):
+            for r in range(ROW_COUNT - NUMBER_TO_WIN + 2):
                 for i in range(NUMBER_TO_WIN - 2):
                     if board[r + i][c + i] != board[r + i + 1][c + i + 1]:
                         break
@@ -322,7 +322,7 @@ class TurnManager:
                         if row_id in (1, 2):
                             lines[row_id - 1] += 1
 
-        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 1):
+        for c in range(COLUMN_COUNT - NUMBER_TO_WIN + 2):
             for r in range(NUMBER_TO_WIN - 2, ROW_COUNT):
                 for i in range(NUMBER_TO_WIN - 2):
                     if board[r - i][c + i] != board[r - i - 1][c + i + 1]:

--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -272,7 +272,7 @@ class TurnManager:
                 self.sets[turn].append((last_pos, 'V'))
         
         # print(self.sets)        
-        return len(self.sets[turn]) == SETS_TO_WIN
+        return len(self.sets[turn]) >= SETS_TO_WIN
     
     # Checks if last move broke a line
     def check_for_break(self, board):

--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -212,7 +212,13 @@ class TurnManager:
                             self.game_over = True
 
                     if len(set(np.where(self.game_board.board[0] == 0)[0]) - set(self.game_board.frozen_columns.keys())) == 0:
-                        self.tiebreak(self.game_board.board)
+                        if self.sets[self.current_player.id] > self.sets[self.other_player.id]:
+                            self.current_player.won = True
+                        elif self.sets[self.current_player.id] < self.sets[self.other_player.id]:
+                            self.other_player.won = True   
+                        else:
+                            self.tiebreak(self.game_board.board)
+                        self.game_over = True
                     
                     if current_tool.ends_turn:
                         self.remaining_drops -= 1
@@ -336,7 +342,6 @@ class TurnManager:
             self.current_player.won = True
         elif lines[self.current_player.id - 1] < lines[self.other_player.id - 1]:
             self.other_player.won = True
-        self.game_over = True
 
 
     def switch_turn(self):  


### PR DESCRIPTION
tiebreak function in turn_manager using the old win condition code that checked the whole board. It gets run if there are no non-frozen columns where the top row is empty and it checks who has the most NUMBER_TO_WIN - 1 long lines. Let me know if something doesn't make sense or should be changed, I did a bad job testing because I kept accidentally winning and eventually got annoyed and stopped testing.

Worth noting that the freeze powerup is very effective in forcing a win if you have more lines than the other player with only few columns still unfilled, I haven't really thought about whether this is overpowered or not.