### PR TITLE
Functionality to return to menu after game finishes

### DIFF
--- a/logic/game_screens/game.py
+++ b/logic/game_screens/game.py
@@ -11,16 +11,20 @@ from logic.components.tool import Tool
 from logic.components.animation import Animation
 from logic.game_screens.menu import config_variables
 
-ROW_COUNT = config_variables["row_count"]
-COLUMN_COUNT = config_variables["column_count"]
-SQUARE_SIZE = config_variables["square_size"]
-ELIGIBLE_TOOLS = config_variables["eligible_tools"]
-NUMBER_TO_WIN = config_variables["number_to_win"]
-SETS_TO_WIN = config_variables["sets_to_win"]
-BULLET_MODE = config_variables["bullet_mode"]
-TOOL_CHANCE = config_variables["tool_chance"]
-VISIBLE_TOOLS = config_variables["visible_tools"]
-START_GAME = config_variables["start_game"]
+def update_globals():
+    global ROW_COUNT, COLUMN_COUNT, SQUARE_SIZE, ELIGIBLE_TOOLS, NUMBER_TO_WIN, SETS_TO_WIN, BULLET_MODE, TOOL_CHANCE, VISIBLE_TOOLS, START_GAME
+    
+    cfg = config_variables
+    ROW_COUNT = cfg["row_count"]
+    COLUMN_COUNT = cfg["column_count"]
+    SQUARE_SIZE = cfg["square_size"]
+    ELIGIBLE_TOOLS = cfg["eligible_tools"]
+    NUMBER_TO_WIN = cfg["number_to_win"]
+    SETS_TO_WIN = cfg["sets_to_win"]
+    BULLET_MODE = cfg["bullet_mode"]
+    TOOL_CHANCE = cfg["tool_chance"]
+    VISIBLE_TOOLS = cfg["visible_tools"]
+    START_GAME = cfg["start_game"]
 
 
 # This contains the main game handling and data
@@ -39,7 +43,10 @@ class Game:
         self.window = pygame.display.set_mode(size)
         self.position = (screen_width / 2, screen_height / 2)
         self.pieces = 0
+        self.return_to_menu = False
         self.clock = pygame.time.Clock()
+        self.game_over = False
+
 
         # Generate tools
         self.tool_locations = {}
@@ -90,10 +97,11 @@ class Game:
         self.renderer = Render(self.window, self.square_size, self.background_colour, self.player_1, self.player_2, self.tool_locations, size, self.game_board.board)
 
         self.game_loop()
-
     
     def game_loop(self):
         while True:
+            if self.return_to_menu:
+                break
             self.clock.tick(60)
             self.turn_manager.timers()
             self.event_handler.events()
@@ -102,6 +110,7 @@ class Game:
                     self.turn_manager.other_player.won = True
                     self.turn_manager.game_over = True
             self.renderer.render(self.game_board.board, self.turn_manager.current_player, self.position, self.turn_manager.current_player.tools[self.turn_manager.tool_index], self.game_board.frozen_columns, self.turn_manager.game_over)
+
 
 class TurnManager:
     def __init__(self, board, position, player_1, player_2, tool_locations):
@@ -386,11 +395,17 @@ class EventHandler:
                 self.mouse_movement(event)
             if event.type == pygame.KEYDOWN and event.key == pygame.K_SPACE and not self.game.turn_manager.tool_used:
                 self.switch_tool(self.game.turn_manager.tool_index)
+            if event.type == pygame.KEYDOWN and event.key == pygame.K_RETURN and self.game.turn_manager.game_over:
+                self.game.return_to_menu = True
+                pygame.mixer.stop()
+                config_variables["start_game"] = False
+
+            
 
         if not BULLET_MODE:
             for layer in ['layer_2', 'layer_3', 'layer_4', 'layer_5', 'layer_6']:
                 if self.game.audio[layer].increasing:
-                    self.game.audio[layer].increase_volume(0.0005)
+                    self.game.audio[layer].increase_volume(0.005)
 
     def clicks(self):
         if not self.game.turn_manager.game_over and not self.game.renderer.paused:
@@ -516,14 +531,18 @@ class Render:
         message_displayed = False
         for player in players:
             if player.won:
-                winner_message = font.render(f"Congats your when", True, (255, 100, 255))
+                winner_message_1 = font.render(f"Congats your when", True, (255, 100, 255))
                 winner_player = font.render(f"player  {player.id}", True, (255, 100, 255))
-                self.window.blit(winner_message, (self.size[0] / 2 - 150, self.size[1] / 2 - 100, 300, 200))
+                menu_message = font.render(f"Press Enter to return to menu", True, (255, 100, 255))
+                self.window.blit(winner_message_1, (self.size[0] / 2 - 150, self.size[1] / 2 - 50, 300, 200))
                 self.window.blit(winner_player, (self.size[0] / 2 - 150, self.size[1] / 2, 300, 200))
+                self.window.blit(menu_message, (self.size[0] / 2 - 150, self.size[1] / 2 + 50, 300, 200))
                 message_displayed = True
         if not message_displayed:
             tie_message = font.render(f"draw :|", True, (255, 100, 255))
             self.window.blit(tie_message, (self.size[0] / 2 - 150, self.size[1] / 2 - 100, 300, 200))
+            self.window.blit(menu_message, (self.size[0] / 2 - 150, self.size[1] / 2, 300, 200))
+
 
     def final_render(self):        
         pygame.display.flip()

--- a/logic/game_screens/menu.py
+++ b/logic/game_screens/menu.py
@@ -13,21 +13,20 @@ config_variables = {
     "start_game": False
 }
 
-pygame.init()
 
-pygame.mixer.music.load(f'./assets/sound/menu_music.wav')
-pygame.mixer.music.play(-1)
-pygame.mixer.music.set_volume(0.2)
-SCREEN_HEIGHT = 640
-SCREEN_WIDTH = 720
-size = (SCREEN_WIDTH, SCREEN_HEIGHT)
-BACKGROUND_COLOUR = (244,164,96)
-window = pygame.display.set_mode(size, pygame.RESIZABLE)
-pygame.display.flip()
+pygame.init()
 
 font = pygame.font.SysFont("arialblack", 40)
 TEXT_COL = (255, 255, 255)
 BUTTON_COL = (210, 105, 30)
+BACKGROUND_COLOUR = (244,164,96)
+SCREEN_HEIGHT = 640
+SCREEN_WIDTH = 720
+size = (SCREEN_WIDTH, SCREEN_HEIGHT)
+window = pygame.display.set_mode(size, pygame.RESIZABLE)
+pygame.display.flip()
+window.fill(BACKGROUND_COLOUR)
+
 
 class Button:
     def __init__(self, name, location, status, appearance, tickable):
@@ -200,6 +199,12 @@ def clicks(event):
             print(button.name)
 
 def run_menu():
+    pygame.mixer.music.load(f'./assets/sound/menu_music.wav')
+    if not config_variables["start_game"]:
+        pygame.mixer.music.play(-1)
+        pygame.mixer.music.set_volume(0.2)
+    window = pygame.display.set_mode(size, pygame.RESIZABLE)
+    pygame.display.flip()
     while True:
 
         #Render
@@ -247,14 +252,13 @@ def run_menu():
                 clicks(event)
 
         if config_variables["start_game"]:
-            pygame.mixer.music.fadeout(1500)
+            pygame.mixer.music.fadeout(750)
             return
         
         pygame.display.flip()
 
 def start_game():
     return config_variables["start_game"]
-
 
 run_menu()
 

--- a/main_game.py
+++ b/main_game.py
@@ -1,9 +1,14 @@
 from logic.game_screens.menu import run_menu, start_game
-from logic.game_screens.game import Game
+from logic.game_screens.game import Game, update_globals
 
 if __name__ == "__main__":
-    run_menu()
-    while not start_game():
-        print(start_game)
-        pass
-    Game()
+    while True:
+        run_menu()
+        while not start_game():
+            pass
+        
+        update_globals()
+        game = Game()
+        game.game_loop()
+        if not game.return_to_menu:
+            break


### PR DESCRIPTION
You can now press enter to return to the menu after a game ends. it has required a couple of changes in the main logic file and there is a small delay after pressing start, related to the music delay as jithin mentioned. I'm flexible on whether we do something about that or just have a fade out transition or something